### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence
+
+# Change the next line to add your own reviewers
+*     @rootstrap/reviewers-express-api-base
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @some_user and not the global
+# owner(s) will be requested for a review.
+
+# *.js    @some_user

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
-
-
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
 


### PR DESCRIPTION
Added CODEOWNERS file to rotate the reviewers so that at least 3 members of the maintainer's team review the files and they are rotating.

Also, as always we can add/remove reviewers manually