### PR TITLE
Fixed random ID user testing + starting file from prod

### DIFF
--- a/__tests__/controllers/users.controller.spec.ts
+++ b/__tests__/controllers/users.controller.spec.ts
@@ -69,8 +69,8 @@ describe('requesting a user', () => {
   });
 
   it('returns http code 404 for non-existing user', async () => {
-    const random = Math.round(Math.random() * 10);
-    const response = await request(app).get(`${API}/users/${random}`);
+    const randomId = Math.round(user.id + (Math.random() * 10));
+    const response = await request(app).get(`${API}/users/${randomId}`);
     expect(response.status).toBe(404);
   });
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "nodemon --watch 'src/**/*.ts' --exec 'ts-node -r tsconfig-paths/register' src/server.ts",
     "prebuild": "rm -rf /dist",
     "build": "tsc",
-    "start": "node -r tsconfig-paths/register -r ts-node/register ./dist/server.js",
+    "start": "node -r tsconfig-paths/register -r ts-node/register ./dist/index.js",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
     "test": "ENVIRONMENT=test jest --runInBand",
     "db:setup": "yarn schema:sync && yarn seed:run",

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -8,8 +8,8 @@ const connection = {
       if (callback) {
         callback(connection);
       }
-    } catch (e) {
-      console.log(e);
+    } catch (error) {
+      throw new Error(`ERROR: Creating test db connection: ${error}`);
     }
   },
 
@@ -25,7 +25,9 @@ const connection = {
       const repository = connection.getRepository(entity.name);
       try {
         await repository.clear();
-      } catch (e) {}
+      } catch (error) {
+        throw new Error(`ERROR: Cleaning test db: ${error}`);
+      }
     });
   }
 };


### PR DESCRIPTION
This PR contains:

- Quick fix for random user id testing, avoiding collision between the user created on the before each
- Changed starting point (target file) for the "production" command.

<img width="521" alt="Screen Shot 2020-10-12 at 10 09 28" src="https://user-images.githubusercontent.com/8084303/95750317-57476080-0c73-11eb-9586-e471461244cc.png">
