### PR TITLE
change flow for dynamic setup node version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,13 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Fetch unshallow
         run: git fetch --unshallow
-      - name: Use Node.js
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+      - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x' # TODO: match nvmrc version
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
       - name: Install dependencies
         run: yarn --frozen-lockfile
       - name: Lint


### PR DESCRIPTION
## Pull request type

<!-- Please check the type of change your PR introduces: -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The current action in main.yml uses a specific hardcoded node version.
Issue Link: [https://github.com/rootstrap/express-api-base/issues/7](https://github.com/rootstrap/express-api-base/issues/7)

## What is the new behavior?

Now, the workflow will take node version dynamically from .nvmrc in the repo.

## Other information

N/A

## Preview

N/A
