### PR TITLE
Change typeorm configuration and how to setup database with migrations

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -9,7 +9,7 @@ TYPEORM_SYNCHRONIZE = true
 TYPEORM_LOGGING = false
 TYPEORM_ENTITIES = src/entities/**/*.ts
 TYPEORM_MIGRATIONS = src/database/migrations/**/*.ts
-TYPEORM_MIGRATIONS_RUN = true
+TYPEORM_MIGRATIONS_RUN = false
 TYPEORM_SEEDING_FACTORIES = src/database/factories/**/*.ts
 TYPEORM_SEEDING_SEEDS = src/database/seeds/**/*.ts
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@
 package-lock.json
 
 ### dotenv ###
-.env
+.env.dev
+.env.test
+.env.prod
 
 ### macOS ###
 # General

--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ This project includes the boilerplate for a basic rest-api made in Node.JS with 
 1. Install Node.js (lts-version v12.18.3)
 2. Install `yarn` if not present `curl -o- -L https://yarnpkg.com/install.sh | bash` (macOS and generic Unix environments)
 3. Install required dependencies by `yarn`
-4. `cp .example.env .env`
+4. `cp .example.env .env.dev`
 5. `cp .example.env.test .env.test`
 6. Create your DB (i.e. psql for Postgres: `psql -U <user> -h <host> -c "create database <db name>;"`) with same name as your .env file.
-7. Run `yarn db:setup`.
-8. Start your server with `yarn dev`.
+7. Run `ENVIRONMENT=[dev, test, prod] yarn migration:run`.
+8. Start your server with `ENVIRONMENT=[dev, prod] yarn dev`.
 
 ## Some scripts
+
+Add `ENVIRONMENT=[dev, prod]` before running scripts.
+Why?: [Configuration file used by Typeorm](https://typeorm.io/#/using-ormconfig/which-configuration-file-is-used-by-typeorm)
 
 Run `yarn build` to build js from typescript source.
 
@@ -30,6 +33,15 @@ Run `yarn schema:sync` to resync the schema of your DB.
 Run `yarn seed:run` to run seed files.
 
 Run `yarn db:reset` to drop schema and re run it, then seed the DB.
+
+Run `yarn migration:generate` to create a new migration.
+
+Run `yarn migration:run` to run pending migrations.
+
+Run `yarn migration:revert` to rollback migrations.
+
+Run `yarn migration:show` to see the list of all migrations (pending and also ran).
+
 
 ## App scaffolding
 

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -1,0 +1,31 @@
+const dotenv = require('dotenv');
+
+const envFile = process.env.ENVIRONMENT
+  ? `.env.${process.env.ENVIRONMENT}`
+  : '.env';
+dotenv.config({ path: envFile });
+
+
+// If .env wasn't provided then exit
+if (!process.env.PORT) {
+  console.error('==> Please check your .env');
+  process.exit(1);
+}
+
+module.exports = {
+  type: 'postgres',
+  host: process.env.TYPEORM_HOST,
+  username: process.env.TYPEORM_USERNAME,
+  password: process.env.TYPEORM_PASSWORD,
+  database: process.env.TYPEORM_DATABASE,
+  port: Number.parseInt(process.env.TYPEORM_PORT || '3000'),
+  synchronize: process.env.TYPEORM_SYNCHRONIZE === 'true',
+  logging: process.env.TYPEORM_LOGGING === 'true',
+  entities: ['src/entities/**/*.ts'],
+  migrations: ['src/database/migrations/**/*.ts'],
+  migrationsRun: process.env.TYPEORM_MIGRATIONS_RUN === 'true',
+  cli: {
+    migrationsDir: 'src/database/migrations',
+    entitiesDir: 'src/entities'
+  }
+};

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -1,10 +1,6 @@
 const dotenv = require('dotenv');
 
-const envFile = process.env.ENVIRONMENT
-  ? `.env.${process.env.ENVIRONMENT}`
-  : '.env';
-dotenv.config({ path: envFile });
-
+dotenv.config({ path: `.env.${process.env.ENVIRONMENT}` });
 
 // If .env wasn't provided then exit
 if (!process.env.PORT) {
@@ -20,7 +16,7 @@ module.exports = {
   database: process.env.TYPEORM_DATABASE,
   port: Number.parseInt(process.env.TYPEORM_PORT || '3000'),
   synchronize: process.env.TYPEORM_SYNCHRONIZE === 'true',
-  logging: process.env.TYPEORM_LOGGING === 'true',
+  logging: process.env.TYPEORM_LOGGING,
   entities: ['src/entities/**/*.ts'],
   migrations: ['src/database/migrations/**/*.ts'],
   migrationsRun: process.env.TYPEORM_MIGRATIONS_RUN === 'true',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "seed:run": "ts-node -r tsconfig-paths/register ./node_modules/typeorm-seeding/dist/cli.js seed",
     "schema:drop": "ts-node ./node_modules/typeorm/cli.js schema:drop",
     "schema:sync": "ts-node ./node_modules/typeorm/cli.js schema:sync",
-    "migration:generate": "yarn run typeorm migration:create -n"
+    "migration:generate": "yarn run typeorm migration:create -n",
+    "migration:revert": "yarn typeorm migration:revert",
+    "migration:show": "yarn typeorm migration:show"
   },
   "jestSonar": {
     "reportPath": "__tests__",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "seed:run": "ts-node -r tsconfig-paths/register ./node_modules/typeorm-seeding/dist/cli.js seed",
     "schema:drop": "ts-node ./node_modules/typeorm/cli.js schema:drop",
     "schema:sync": "ts-node ./node_modules/typeorm/cli.js schema:sync",
-    "migration:generate": "yarn run typeorm migration:create -n",
+    "migration:generate": "yarn typeorm migration:create -n",
     "migration:revert": "yarn typeorm migration:revert",
-    "migration:show": "yarn typeorm migration:show"
+    "migration:show": "yarn typeorm migration:show",
+    "migration:run": "yarn typeorm migration:run"
   },
   "jestSonar": {
     "reportPath": "__tests__",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,4 @@
 import * as dotenv from 'dotenv';
-import { ConnectionOptions } from 'typeorm';
 
 const envFile = process.env.ENVIRONMENT
   ? `.env.${process.env.ENVIRONMENT}`
@@ -11,24 +10,6 @@ if (!process.env.PORT) {
   console.error('==> Please check your .env');
   process.exit(1);
 }
-
-export const databaseConfig: ConnectionOptions = {
-  type: 'postgres',
-  host: process.env.TYPEORM_HOST,
-  username: process.env.TYPEORM_USERNAME,
-  password: process.env.TYPEORM_PASSWORD,
-  database: process.env.TYPEORM_DATABASE,
-  port: Number.parseInt(process.env.TYPEORM_PORT || '3000'),
-  synchronize: process.env.TYPEORM_SYNCHRONIZE === 'true',
-  logging: process.env.TYPEORM_LOGGING === 'true',
-  entities: ['src/entities/**/*.ts'],
-  migrations: ['src/database/migrations/**/*.ts'],
-  migrationsRun: process.env.TYPEORM_MIGRATIONS_RUN === 'true',
-  cli: {
-    migrationsDir: 'src/database/migrations/**/*.ts',
-    entitiesDir: 'src/entities/**/*.ts'
-  }
-};
 
 export const {
   ENVIRONMENT,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,9 +1,6 @@
-import * as dotenv from 'dotenv';
+const dotenv = require('dotenv');
 
-const envFile = process.env.ENVIRONMENT
-  ? `.env.${process.env.ENVIRONMENT}`
-  : '.env';
-dotenv.config({ path: envFile });
+dotenv.config({ path: `.env.${process.env.ENVIRONMENT}` });
 
 // If .env wasn't provided then exit
 if (!process.env.PORT) {

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -1,10 +1,10 @@
 import { createConnection, getConnection, Connection } from 'typeorm';
-import { databaseConfig } from '@config';
+import config from '@ormconfig';
 
 const connection = {
   async create(callback?: (c: Connection) => void): Promise<void> {
     try {
-      const connection = await createConnection(databaseConfig);
+      const connection = await createConnection(config);
       if (callback) {
         callback(connection);
       }

--- a/src/database/migrations/1606158886329-CreateUserEntity.ts
+++ b/src/database/migrations/1606158886329-CreateUserEntity.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateUserEntity1606158886329 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+    CREATE TABLE "user" (firstName varchar(255),
+    lastName varchar(255), email varchar(255), password varchar(255))`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "user"`);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
       "@entities/*": ["src/entities/*"],
       "@middlewares/*": ["src/middlewares/*"],
       "@services/*": ["src/services/*"],
-      "@app": ["src/app"]
+      "@app": ["src/app"],
+      "@ormconfig": ["ormconfig"]
     },
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Pull request type

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- Currently since we have a `.env` file, Typeorm will read the configuration from there. Preventing from reading from other env files.
- Since we are using `schema:sync`, if the database already has migrations it won't read them since it creates the DB schema from the entities

Issue Link: [Init database with migrations](https://github.com/typeorm/typeorm/issues/2961)

## What is the new behavior?

- Create an `ormconfig.js` with the values from each `.env.[environment]` file
- Created an init migration to read and create the DB from there. We have to run: `ENVIRONMENT=[dev, test, prod] yarn typeorm migration:run`.

## Other information

- We might need to look for the SQL query to create correctly the data for each column. Not sure if `varchar(255)` is needed right now for every user column

## Preview

N/A
