### PR TITLE
User public fields method

### DIFF
--- a/__tests__/controllers/auth.controller.spec.ts
+++ b/__tests__/controllers/auth.controller.spec.ts
@@ -26,6 +26,13 @@ describe('creating an account', () => {
       .post(`${API}/auth/signup`)
       .send(userFields);
     expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        email: expect.any(String)
+      })
+    );
   });
 
   it('returns http code 400 whith invalid params', async () => {

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,6 +1,7 @@
 import { Entity, Column, BeforeInsert } from 'typeorm';
 import { IsEmail, validateOrReject, IsNotEmpty } from 'class-validator';
 import { compareSync, hashSync, genSaltSync } from 'bcrypt';
+import _ from 'lodash';
 import { Base } from './base.entity';
 
 @Entity()
@@ -31,5 +32,9 @@ export class User extends Base {
 
   private hashPassword() {
     this.password = hashSync(this.password, genSaltSync());
+  }
+
+  public publicFields() {
+    return _.pick(this, ['firstName', 'lastName', 'email']);
   }
 }


### PR DESCRIPTION
## Pull request type

- [ X ] Bugfix
- [ X ] Feature

## What is the current behavior?

The API is currently sending the user token as body data when signing in.

Issue Link: N/A

## What is the new behavior?

Most authentication methods use headers for this, this change updates the auth controller for doing it, and includes a helper function for the user to return public fields to be consumed by the client.
