### PR TITLE
Change nullable fields to actually be nullable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,7 @@ dist
 .scannerwork
 sonar-project.properties
 test-report.xml
+
+# IDE
+.idea
+

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,5 +1,5 @@
 import { Entity, Column, BeforeInsert } from 'typeorm';
-import { IsEmail, validateOrReject, IsNotEmpty } from 'class-validator';
+import { IsEmail, validateOrReject, IsNotEmpty, IsString } from 'class-validator';
 import { compareSync, hashSync, genSaltSync } from 'bcrypt';
 import { Base } from './base.entity';
 
@@ -12,10 +12,12 @@ export class User extends Base {
   }
 
   @Column({ nullable: true })
-  firstName!: string;
+  @IsString()
+  firstName?: string;
 
   @Column({ nullable: true })
-  lastName!: string;
+  @IsString()
+  lastName?: string;
 
   @Column()
   @IsEmail()


### PR DESCRIPTION
## Pull request type

<!-- Please check the type of change your PR introduces: -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
If we try to create a user with what the docs says (email and password, since the first and last name are nullable) it will throw an error since by typescript it's requiring those fields (use of bang in the declaration of the field). If we don't want these fields we have to replace `!` with `?`.
Added `.idea` (webstorm) to `.gitignore`

Issue Link: N/A

## What is the new behavior?
User can be created without first and last name

## Other information

<!-- Please add any relevant information that assists the code review. -->

N/A

## Preview

N/A
