### PR TITLE
Added conditional to prevent sonarqube failing with dependabots PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,10 @@ jobs:
       # Before running the scan, typescript must be installed from npm and
       # NODE_PATH env var must point to tsc bin folder, otherways typescript static analysis will fail
       - name: Setup sonar scanner
+        if: github.actor != 'dependabot[bot]'
         uses: warchant/setup-sonar-scanner@v3
       - name: Run Sonarqube analysis
+        if: github.actor != 'dependabot[bot]'
         run: |
           echo "NODE_PATH=$(which tsc)" >> $GITHUB_ENV
           sonar-scanner -Dsonar.verbose=false -Dsonar.qualitygate.wait=true -Dsonar.host.url=${{ secrets.SONAR_URL }} -Dsonar.login=${{ secrets.SONAR_TOKEN }} -Dsonar.projectKey=${{secrets.SONAR_PROJECT_KEY }} -Dsonar.scm.provider=git -Dsonar.java.binaries=/tmp -Dsonar.nodejs.executable=$(which node) -Dsonar.projectVersion=$(echo $GITHUB_SHA | cut -c1-8) -Dsonar.sources=. -Dsonar.projectBaseDir=.


### PR DESCRIPTION
## Pull request type

<!-- Please check the type of change your PR introduces: -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- PRs created by @dependabot are failing the sonarqube test step, avoiding keeping the base updated

Issue Link: closes #510

## What is the new behavior?

- Sonarqube steps are going to be skipped when Dependabot creates a PR
