### PR TITLE
Skip node internal files on VsCode debugger

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
     "sourceType": "module"
   },
   "rules": {
-    "indent": ["error", 2],
+    "indent": ["error", 2, { "SwitchCase": 1 }],
     "comma-dangle": ["error", "never"],
     "object-curly-spacing": ["error", "always"],
     "curly": ["error", "all"],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,14 +7,17 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "yarn",
+      "name": "Run in Development",
       "runtimeExecutable": "yarn",
       "runtimeArgs": [
         "dev"
       ],
       "port": 3000,
       "cwd": "${workspaceRoot}",
-      "timeout": 10000
+      "timeout": 10000,
+      "skipFiles": [
+        "<node_internals>/**"
+      ]
     },
     {
       "type": "node",

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -40,10 +40,10 @@ export class AuthController {
       return { token };
     } catch (error) {
       switch (error?.message) {
-      case Errors.MISSING_PARAMS:
-        throw new BadRequestError(Errors.MISSING_PARAMS);
-      default:
-        throw new UnauthorizedError(Errors.INVALID_CREDENTIALS);
+        case Errors.MISSING_PARAMS:
+          throw new BadRequestError(Errors.MISSING_PARAMS);
+        default:
+          throw new UnauthorizedError(Errors.INVALID_CREDENTIALS);
       }
     }
   }


### PR DESCRIPTION
## Pull request type

<!-- Please check the type of change your PR introduces: -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe): Debugging enhancement

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The debugger automatically stops on internal Node files, such as `async_hooks`.

Issue Link: N/A

## What is the new behavior?

- All internal Node files are skipped
- Added rule for better switch indentation

## Other information

<!-- Please add any relevant information that assists the code review. -->

N/A

## Preview

N/A
