### PR TITLE
Feat default error handler

### DIFF
--- a/__tests__/controllers/auth/create-account.spec.ts
+++ b/__tests__/controllers/auth/create-account.spec.ts
@@ -23,15 +23,22 @@ describe('creating an account', () => {
     expect(response.status).toBe(400);
   });
 
-  it('returns http code 400 with a short password', async () => {
+  it('returns http code 400 with 4 errors on the errors field', async () => {
     const userFields = {};
     const response = await request(app)
       .post(`${API}/auth/signup`)
       .send(userFields);
-    expect(response.body).toStrictEqual(expect.objectContaining({
-      description: ErrorsMessages.PASSWORD_ERROR,
+    expect(response.body).toStrictEqual({
+      description: ErrorsMessages.BODY_ERRORS,
+      errors: [
+        'Property firstName must be a string',
+        'Property lastName must be a string',
+        'Property email must be an email',
+        'Property Password is too short, the minimum length is 6 characters.'
+      ],
       httpCode: HttpStatusCode.BAD_REQUEST,
-      name: ErrorsMessages.BAD_REQUEST_ERROR
-    }));
+      name: 'Bad request error'
+    });
+    expect(response.body.errors).toHaveLength(4);
   });
 });

--- a/__tests__/controllers/auth/create-account.spec.ts
+++ b/__tests__/controllers/auth/create-account.spec.ts
@@ -3,9 +3,11 @@ import app from '@app';
 import { factory } from 'typeorm-seeding';
 import { User } from '@entities/user.entity';
 import { API } from '../../utils';
+import { Errors, ErrorsMessages } from '@constants/errorMessages';
+import { HttpStatusCode } from '@constants/httpStatusCode';
 
 describe('creating an account', () => {
-  it('returns http code 200 whith valid params', async () => {
+  it('returns http code 200 with valid params', async () => {
     const userFields = await factory(User)().make();
     const response = await request(app)
       .post(`${API}/auth/signup`)
@@ -13,17 +15,23 @@ describe('creating an account', () => {
     expect(response.status).toBe(200);
   });
 
-  it('returns http code 400 whith invalid params', async () => {
+  it('returns http code 400 with invalid params', async () => {
     const userFields = {};
     const response = await request(app)
       .post(`${API}/auth/signup`)
       .send(userFields);
     expect(response.status).toBe(400);
-    expect(response.body).toStrictEqual(
-      expect.objectContaining({
-        errMessage: expect.any(String),
-        errCode: expect.any(Number)
-      })
-    );
+  });
+
+  it('returns http code 400 with a short password', async () => {
+    const userFields = {};
+    const response = await request(app)
+      .post(`${API}/auth/signup`)
+      .send(userFields);
+    expect(response.body).toStrictEqual(expect.objectContaining({
+      description: ErrorsMessages.PASSWORD_ERROR,
+      httpCode: HttpStatusCode.BAD_REQUEST,
+      name: ErrorsMessages.BAD_REQUEST_ERROR
+    }));
   });
 });

--- a/__tests__/controllers/auth/create-session.spec.ts
+++ b/__tests__/controllers/auth/create-session.spec.ts
@@ -36,11 +36,10 @@ describe('creating a session', () => {
       .post(`${API}/auth/signin`)
       .send(authFields);
     expect(response.status).toBe(401);
-    expect(response.body).toStrictEqual(
-      expect.objectContaining({
-        errMessage: expect.any(String),
-        errCode: expect.any(Number)
-      })
-    );
+    expect(response.body).toStrictEqual({
+      description: 'Invalid credentials',
+      httpCode: 401,
+      name: 'UnauthorizedError'
+    });
   });
 });

--- a/__tests__/controllers/users/create-user.spec.ts
+++ b/__tests__/controllers/users/create-user.spec.ts
@@ -5,7 +5,6 @@ import app from '@app';
 import { User } from '@entities/user.entity';
 import { API } from '../../utils';
 import { HttpStatusCode } from '@constants/httpStatusCode';
-import { Errors } from '@constants/errorMessages';
 
 describe('creating a user', () => {
   it('returns http code 200 and creates the user', async () => {

--- a/__tests__/controllers/users/create-user.spec.ts
+++ b/__tests__/controllers/users/create-user.spec.ts
@@ -4,7 +4,8 @@ import { factory } from 'typeorm-seeding';
 import app from '@app';
 import { User } from '@entities/user.entity';
 import { API } from '../../utils';
-import { REGEX } from '@constants/regex';
+import { HttpStatusCode } from '@constants/httpStatusCode';
+import { Errors } from '@constants/errorMessages';
 
 describe('creating a user', () => {
   it('returns http code 200 and creates the user', async () => {
@@ -16,7 +17,7 @@ describe('creating a user', () => {
     const userRepo = getRepository<User>(User);
     expect(await userRepo.count()).toBeGreaterThan(0);
   });
-  
+
   it('returns http code 400 if user email already exists', async () => {
     const userFields = await factory(User)().create();
 
@@ -32,7 +33,11 @@ describe('creating a user', () => {
       .post(`${API}/users`)
       .send(userFields);
     expect(failingResponse.status).toBe(400);
-    expect(failingResponse.body?.errMessage).toMatch(REGEX.DB_INDEX_ERROR);
+    expect(failingResponse.body).toStrictEqual({
+      description: expect.stringContaining(userFields.email),
+      httpCode: HttpStatusCode.BAD_REQUEST,
+      name: "BadRequestError"
+    });
 
     expect(await userRepo.count()).toBe(1);
   });

--- a/__tests__/controllers/users/get-users.spec.ts
+++ b/__tests__/controllers/users/get-users.spec.ts
@@ -5,11 +5,17 @@ import app from '@app';
 import { User } from '@entities/user.entity';
 import { JWTService } from '@services/jwt.service';
 import { API } from '../../utils';
+import { HttpStatusCode } from '@constants/httpStatusCode';
 
 describe('requesting all users', () => {
   let user: User;
   let token: string;
   const jwtService = Container.get(JWTService);
+  const unAuthenticatedError = {
+    description: 'Authorization is required for request on GET /api/v1/users',
+    httpCode: 401,
+    name: 'AuthorizationRequiredError'
+  };
 
   beforeEach(async () => {
     user = await factory(User)().create();
@@ -20,10 +26,7 @@ describe('requesting all users', () => {
     const response = await request(app).get(`${API}/users`);
     expect(response.status).toBe(401);
     expect(response.body).toStrictEqual(
-      expect.objectContaining({
-        errMessage: expect.any(String),
-        errCode: expect.any(Number)
-      })
+      expect.objectContaining(unAuthenticatedError)
     );
   });
 
@@ -33,10 +36,7 @@ describe('requesting all users', () => {
       .set({ Authorization: 'Inv3nT3d-T0k3N' });
     expect(response.status).toBe(401);
     expect(response.body).toStrictEqual(
-      expect.objectContaining({
-        errMessage: expect.any(String),
-        errCode: expect.any(Number)
-      })
+      expect.objectContaining(unAuthenticatedError)
     );
   });
 
@@ -65,8 +65,8 @@ describe('requesting all users', () => {
     expect(response.status).toBe(404);
     expect(response.body).toStrictEqual(
       expect.objectContaining({
-        errMessage: expect.any(String),
-        errCode: expect.any(Number)
+        httpCode: HttpStatusCode.NOT_FOUND,
+        name: 'NotFoundError'
       })
     );
   });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prod": "ENV=prod node -r ./prod-paths.js ./dist/src/server.js",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
     "posttypeorm": "prettier -w src/database/migrations",
-    "test": "ENV=test jest --runInBand --forceExit --detectOpenHandles --useStderr",
+    "test": "ENV=test jest --runInBand --forceExit --detectOpenHandles --useStderr --silent",
     "test:cover": "yarn test --coverage",
     "test:ci": "ENV=ci jest --runInBand --forceExit --detectOpenHandles --coverage",
     "db:setup": "yarn typeorm schema:sync && yarn seed:run",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prod": "ENV=prod node -r ./prod-paths.js ./dist/src/server.js",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
     "posttypeorm": "prettier -w src/database/migrations",
-    "test": "ENV=test jest --runInBand --forceExit --detectOpenHandles --useStderr --silent",
+    "test": "ENV=test jest --runInBand --forceExit --detectOpenHandles --useStderr",
     "test:cover": "yarn test --coverage",
     "test:ci": "ENV=ci jest --runInBand --forceExit --detectOpenHandles --coverage",
     "db:setup": "yarn typeorm schema:sync && yarn seed:run",

--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -12,13 +12,12 @@ export enum ErrorsMessages {
   REDIS_ERROR = 'Error in redis database',
   REDIS_ERROR_SET_TOKEN = 'Error at set user token in blacklist',
   UNKNOWN = 'Unknown error',
-  DEFAULT = 'Internal Server Error',
   PASSWORD_ERROR = 'Password is too short, the minimum length is 6 characters.',
   BODY_ERRORS = "You have errors in your request's body." +
     "Check 'errors' field for more details.",
 
   // HTTP STANDARD MESSAGES
-  INTERNAL_SERVER_ERROR = 'Internal server error',
+  INTERNAL_SERVER_ERROR = 'Internal Server Error',
   BAD_REQUEST_ERROR = 'Bad request error'
 }
 
@@ -34,5 +33,7 @@ export const Errors = {
     502,
     ErrorsMessages.EMAIL_NOT_SENT
   ),
-  [ErrorsMessages.DEFAULT]: new InternalServerError(ErrorsMessages.DEFAULT)
+  [ErrorsMessages.BAD_REQUEST_ERROR]: new InternalServerError(
+    ErrorsMessages.BAD_REQUEST_ERROR
+  )
 };

--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -12,7 +12,14 @@ export enum ErrorsMessages {
   REDIS_ERROR = 'Error in redis database',
   REDIS_ERROR_SET_TOKEN = 'Error at set user token in blacklist',
   UNKNOWN = 'Unknown error',
-  DEFAULT = 'Internal Server Error'
+  DEFAULT = 'Internal Server Error',
+  PASSWORD_ERROR = 'Password is too short, the minimum length is 6 characters.',
+  BODY_ERRORS = "You have errors in your request's body." +
+    "Check 'errors' field for more details.",
+
+  // HTTP STANDARD MESSAGES
+  INTERNAL_SERVER_ERROR = 'Internal server error',
+  BAD_REQUEST_ERROR = 'Bad request error'
 }
 
 export const Errors = {

--- a/src/constants/httpStatusCode.ts
+++ b/src/constants/httpStatusCode.ts
@@ -1,0 +1,7 @@
+export enum HttpStatusCode {
+    OK = 200,
+    BAD_REQUEST = 400,
+    FORBIDDEN = 403,
+    NOT_FOUND = 404,
+    INTERNAL_SERVER = 500,
+   }

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -39,7 +39,7 @@ export class AuthController {
       const token = await this.sessionService.signIn({ email, password });
       return { token };
     } catch (error) {
-      throw Errors[error.message] || Errors[ErrorsMessages.DEFAULT];
+      throw Errors[error.message] || Errors[ErrorsMessages.INTERNAL_SERVER_ERROR];
     }
   }
 

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -13,7 +13,9 @@ import { Service } from 'typedi';
 import { User } from '@entities/user.entity';
 import { SessionService } from '@services/session.service';
 import { Errors, ErrorsMessages } from '@constants/errorMessages';
-import { Request, Response } from 'express';
+import { UserDTO } from '@dto/userDTO';
+import { Request } from 'express';
+import { EntityMapper } from '@utils/mapper/entityMapper.service';
 
 @JsonController('/auth')
 @Service()
@@ -21,16 +23,11 @@ export class AuthController {
   constructor(private readonly sessionService: SessionService) {}
 
   @Post('/signup')
-  async signUp(
-    @Body({ validate: false }) user: User,
-    @Res() response: Response
-  ) {
-    try {
-      const newUser = await this.sessionService.signUp(user);
-      return response.send(omit(newUser, ['password']));
-    } catch (error) {
-      throw Errors[error.message] || Errors[ErrorsMessages.DEFAULT];
-    }
+  async signUp(@Body({ validate: true }) user: UserDTO, @Res() response: any) {
+    const newUser = await this.sessionService.signUp(
+      EntityMapper.mapTo(User, user)
+    );
+    return response.send(omit(newUser, ['password']));
   }
 
   @Post('/signin')

--- a/src/controllers/users.controller.ts
+++ b/src/controllers/users.controller.ts
@@ -37,7 +37,7 @@ export class UserController {
       return await this.usersService.createUser(user);
     } catch (error: any) {
       throw new BadRequestError(
-        error.detail ?? error.message ?? ErrorsMessages.DEFAULT
+        error.detail ?? error.message ?? ErrorsMessages.INTERNAL_SERVER_ERROR
       );
     }
   }

--- a/src/dto/userDTO.ts
+++ b/src/dto/userDTO.ts
@@ -1,0 +1,15 @@
+import { Errors } from '@constants/errorMessages';
+import { IsEmail, IsString, MinLength } from 'class-validator';
+export class UserDTO {
+  @IsString()
+  firstName?: string;
+
+  @IsString()
+  lastName?: string;
+
+  @IsEmail()
+  email!: string;
+
+  @MinLength(6, { message: Errors.PASSWORD_ERROR })
+  password!: string;
+}

--- a/src/dto/userDTO.ts
+++ b/src/dto/userDTO.ts
@@ -1,4 +1,4 @@
-import { Errors } from '@constants/errorMessages';
+import { ErrorsMessages } from '@constants/errorMessages';
 import { IsEmail, IsString, MinLength } from 'class-validator';
 export class UserDTO {
   @IsString()
@@ -10,6 +10,6 @@ export class UserDTO {
   @IsEmail()
   email!: string;
 
-  @MinLength(6, { message: Errors.PASSWORD_ERROR })
+  @MinLength(6, { message: ErrorsMessages.PASSWORD_ERROR })
   password!: string;
 }

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,34 +1,17 @@
-import { BeforeInsert, Column, Entity, Index } from 'typeorm';
-import {
-  IsEmail,
-  IsNotEmpty,
-  IsString,
-  validateOrReject
-} from 'class-validator';
-
+import { Column, Entity, Index } from 'typeorm';
 import { Base } from './base.entity';
-
 @Entity()
 export class User extends Base {
-  @BeforeInsert()
-  async beforeInsert() {
-    await validateOrReject(this);
-  }
-
   @Column({ nullable: true })
-  @IsString()
   firstName?: string;
 
   @Column({ nullable: true })
-  @IsString()
   lastName?: string;
 
   @Column()
-  @IsEmail()
   @Index({ unique: true })
   email!: string;
 
   @Column({ select: false })
-  @IsNotEmpty()
   password!: string;
 }

--- a/src/exception/base.error.ts
+++ b/src/exception/base.error.ts
@@ -1,0 +1,22 @@
+import { HttpStatusCode } from '@constants/httpStatusCode';
+
+// eslint-disable-next-line
+//Information on captureStackTrace https://stackoverflow.com/questions/59625425/understanding-error-capturestacktrace-and-stack-trace-persistance
+// eslint-disable-next-line
+// Information on setPrototypeOf https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
+export class BaseError extends Error {
+  public readonly name: string;
+  public readonly httpCode: HttpStatusCode;
+  public readonly description: string;
+
+  constructor(name: string, httpCode: HttpStatusCode, description: string) {
+    super(description);
+    Object.setPrototypeOf(this, new.target.prototype);
+
+    this.httpCode = httpCode;
+    this.name = name;
+    this.description = description;
+
+    Error.captureStackTrace(this);
+  }
+}

--- a/src/exception/base.error.ts
+++ b/src/exception/base.error.ts
@@ -1,9 +1,5 @@
 import { HttpStatusCode } from '@constants/httpStatusCode';
 
-// eslint-disable-next-line
-//Information on captureStackTrace https://stackoverflow.com/questions/59625425/understanding-error-capturestacktrace-and-stack-trace-persistance
-// eslint-disable-next-line
-// Information on setPrototypeOf https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
 export class BaseError extends Error {
   public readonly name: string;
   public readonly httpCode: HttpStatusCode;

--- a/src/exception/database.error.ts
+++ b/src/exception/database.error.ts
@@ -1,0 +1,9 @@
+import { Errors } from '@constants/errorMessages';
+import { BaseError } from './base.error';
+import { HttpStatusCode } from '../constants/httpStatusCode';
+
+export class DatabaseError extends BaseError {
+  constructor(description) {
+    super(Errors.INTERNAL_SERVER_ERROR, HttpStatusCode.INTERNAL_SERVER, description);
+  }
+}

--- a/src/exception/database.error.ts
+++ b/src/exception/database.error.ts
@@ -1,9 +1,13 @@
-import { Errors } from '@constants/errorMessages';
+import { ErrorsMessages } from '@constants/errorMessages';
 import { BaseError } from './base.error';
 import { HttpStatusCode } from '../constants/httpStatusCode';
 
 export class DatabaseError extends BaseError {
   constructor(description) {
-    super(Errors.INTERNAL_SERVER_ERROR, HttpStatusCode.INTERNAL_SERVER, description);
+    super(
+      ErrorsMessages.INTERNAL_SERVER_ERROR,
+      HttpStatusCode.INTERNAL_SERVER,
+      description
+    );
   }
 }

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -1,32 +1,75 @@
+import { DEV_ENV } from '@config';
+import { Errors } from '@constants/errorMessages';
+import { HttpStatusCode } from '@constants/httpStatusCode';
+import { ValidationError } from 'class-validator';
 import { Request, Response } from 'express';
 import {
-  Middleware,
-  ExpressErrorMiddlewareInterface
+  ExpressErrorMiddlewareInterface,
+  Middleware
 } from 'routing-controllers';
-import { DEV_ENV } from '@config';
 import { Service } from 'typedi';
 
 interface ErrorInterface extends Error {
+  name: string;
   httpCode: number;
+  description: string;
+  errors: string[] | undefined;
 }
 
 @Middleware({ type: 'after' })
 @Service()
 export class ErrorMiddleware implements ExpressErrorMiddlewareInterface {
-  error(
-    error: ErrorInterface,
+  public error(
+    error: any,
     _req: Request,
     res: Response,
-    _next: (err?: ErrorInterface) => ErrorInterface
+    _next: (err?: any) => any
   ) {
-    if (DEV_ENV) {
-      console.error(`Message: ${error.message}`);
-      console.error(`Stack: ${error.stack}`);
+    const responseObject = {} as ErrorInterface;
+
+    // If the error comes from the class-validator then it's an array of ValidationError
+    if (
+      Array.isArray(error.errors) &&
+      error.errors.every(element => element instanceof ValidationError)
+    ) {
+      res.status(HttpStatusCode.BAD_REQUEST);
+      // I think we shoudn't send the code as a field. We have HTTP for that.
+      // Also this generate code duplication.
+      responseObject.httpCode = HttpStatusCode.BAD_REQUEST;
+      responseObject.name = Errors.BAD_REQUEST_ERROR;
+      responseObject.description = Errors.BODY_ERRORS;
+      responseObject.errors = [];
+
+      error.errors.forEach((element: ValidationError) => {
+        const constraints = element.constraints || Object;
+        Object.keys(constraints).forEach(type => {
+          responseObject.errors?.push(`Property ${constraints[type]}`);
+        });
+      });
+    } else {
+      // If it's not a 400 family error, then it will not have multiple errors.
+      responseObject.errors = undefined;
+      responseObject.name = error.name; // The name will apear always
+      if (error.httpCode) {
+        responseObject.httpCode = error.httpCode;
+        res.status(error.httpCode);
+      } else {
+        responseObject.httpCode = HttpStatusCode.INTERNAL_SERVER;
+        res.status(HttpStatusCode.INTERNAL_SERVER);
+      }
+
+      const developmentMode: boolean = DEV_ENV ? true : false;
+      if (developmentMode) {
+        responseObject.stack = error.stack;
+      }
+      if (error instanceof Error) {
+        // All our errors should extends from BaseError that extends from Error
+        responseObject.description = error.message;
+      } else if (typeof error === 'string') {
+        responseObject.description = error;
+      }
     }
-    res.status(error.httpCode || 500);
-    res.json({
-      errCode: error.httpCode,
-      errMessage: error.message
-    });
+
+    res.json(responseObject);
   }
 }

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -33,9 +33,17 @@ export class ErrorMiddleware implements ExpressErrorMiddlewareInterface {
       error.errors.every(element => element instanceof ValidationError)
     ) {
       res.status(HttpStatusCode.BAD_REQUEST);
-      // I think we shoudn't send the code as a field. We have HTTP for that.
-      // Also this generate code duplication.
-      this.getClassValidatorResponse(responseObject, error);
+      responseObject.httpCode = HttpStatusCode.BAD_REQUEST;
+      responseObject.name = ErrorsMessages.BAD_REQUEST_ERROR;
+      responseObject.description = ErrorsMessages.BODY_ERRORS;
+      responseObject.errors = [];
+
+      error.errors.forEach((element: ValidationError) => {
+        const constraints = element.constraints || Object;
+        Object.keys(constraints).forEach(type => {
+          responseObject.errors?.push(`Property ${constraints[type]}`);
+        });
+      });
     } else {
       // If it's not a 400, then it will not have multiple errors.
       responseObject.errors = undefined;
@@ -60,24 +68,6 @@ export class ErrorMiddleware implements ExpressErrorMiddlewareInterface {
         responseObject.description = undefined;
       }
     }
-
     res.json(responseObject);
-  }
-
-  private getClassValidatorResponse(
-    responseObject: ErrorInterface,
-    error: any
-  ) {
-    responseObject.httpCode = HttpStatusCode.BAD_REQUEST;
-    responseObject.name = ErrorsMessages.BAD_REQUEST_ERROR;
-    responseObject.description = ErrorsMessages.BODY_ERRORS;
-    responseObject.errors = [];
-
-    error.errors.forEach((element: ValidationError) => {
-      const constraints = element.constraints || Object;
-      Object.keys(constraints).forEach(type => {
-        responseObject.errors?.push(`Property ${constraints[type]}`);
-      });
-    });
   }
 }

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -35,17 +35,7 @@ export class ErrorMiddleware implements ExpressErrorMiddlewareInterface {
       res.status(HttpStatusCode.BAD_REQUEST);
       // I think we shoudn't send the code as a field. We have HTTP for that.
       // Also this generate code duplication.
-      responseObject.httpCode = HttpStatusCode.BAD_REQUEST;
-      responseObject.name = ErrorsMessages.BAD_REQUEST_ERROR;
-      responseObject.description = ErrorsMessages.BODY_ERRORS;
-      responseObject.errors = [];
-
-      error.errors.forEach((element: ValidationError) => {
-        const constraints = element.constraints || Object;
-        Object.keys(constraints).forEach(type => {
-          responseObject.errors?.push(`Property ${constraints[type]}`);
-        });
-      });
+      this.getClassValidatorResponse(responseObject, error);
     } else {
       // If it's not a 400, then it will not have multiple errors.
       responseObject.errors = undefined;
@@ -57,9 +47,7 @@ export class ErrorMiddleware implements ExpressErrorMiddlewareInterface {
         responseObject.httpCode = HttpStatusCode.INTERNAL_SERVER;
         res.status(HttpStatusCode.INTERNAL_SERVER);
       }
-
-      const developmentMode: boolean = DEV_ENV ? true : false;
-      if (developmentMode) {
+      if (DEV_ENV) {
         responseObject.stack = error.stack;
       }
       if (error instanceof Error) {
@@ -74,5 +62,22 @@ export class ErrorMiddleware implements ExpressErrorMiddlewareInterface {
     }
 
     res.json(responseObject);
+  }
+
+  private getClassValidatorResponse(
+    responseObject: ErrorInterface,
+    error: any
+  ) {
+    responseObject.httpCode = HttpStatusCode.BAD_REQUEST;
+    responseObject.name = ErrorsMessages.BAD_REQUEST_ERROR;
+    responseObject.description = ErrorsMessages.BODY_ERRORS;
+    responseObject.errors = [];
+
+    error.errors.forEach((element: ValidationError) => {
+      const constraints = element.constraints || Object;
+      Object.keys(constraints).forEach(type => {
+        responseObject.errors?.push(`Property ${constraints[type]}`);
+      });
+    });
   }
 }

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -12,7 +12,7 @@ import { Service } from 'typedi';
 interface ErrorInterface extends Error {
   name: string;
   httpCode: number;
-  description: string;
+  description: string | undefined;
   errors: string[] | undefined;
 }
 
@@ -47,7 +47,7 @@ export class ErrorMiddleware implements ExpressErrorMiddlewareInterface {
         });
       });
     } else {
-      // If it's not a 400 family error, then it will not have multiple errors.
+      // If it's not a 400, then it will not have multiple errors.
       responseObject.errors = undefined;
       responseObject.name = error.name; // The name will apear always
       if (error.httpCode) {
@@ -67,6 +67,9 @@ export class ErrorMiddleware implements ExpressErrorMiddlewareInterface {
         responseObject.description = error.message;
       } else if (typeof error === 'string') {
         responseObject.description = error;
+      }
+      if (responseObject.description === '') {
+        responseObject.description = undefined;
       }
     }
 

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -1,5 +1,5 @@
 import { DEV_ENV } from '@config';
-import { Errors } from '@constants/errorMessages';
+import { ErrorsMessages } from '@constants/errorMessages';
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { ValidationError } from 'class-validator';
 import { Request, Response } from 'express';
@@ -36,8 +36,8 @@ export class ErrorMiddleware implements ExpressErrorMiddlewareInterface {
       // I think we shoudn't send the code as a field. We have HTTP for that.
       // Also this generate code duplication.
       responseObject.httpCode = HttpStatusCode.BAD_REQUEST;
-      responseObject.name = Errors.BAD_REQUEST_ERROR;
-      responseObject.description = Errors.BODY_ERRORS;
+      responseObject.name = ErrorsMessages.BAD_REQUEST_ERROR;
+      responseObject.description = ErrorsMessages.BODY_ERRORS;
       responseObject.errors = [];
 
       error.errors.forEach((element: ValidationError) => {

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -19,8 +19,7 @@ export class SessionService {
   async signUp(user: User) {
     try {
       this.userService.hashUserPassword(user);
-      await this.userRepository.save(user);
-      return user;
+      return await this.userRepository.save(user);
     } catch (error) {
       throw new DatabaseError(error.message + ' ' + error.detail);
     }

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -5,6 +5,7 @@ import { User } from '@entities/user.entity';
 import { UsersService } from '@services/users.service';
 import { RedisService } from '@services/redis.service';
 import { AuthInterface } from '@interfaces';
+import { DatabaseError } from '@exception/database.error';
 
 @Service()
 export class SessionService {
@@ -16,16 +17,13 @@ export class SessionService {
   private readonly userRepository = getRepository<User>(User);
 
   async signUp(user: User) {
-    let newUser: User;
-
     try {
       this.userService.hashUserPassword(user);
-      newUser = await this.userRepository.save(user);
+      await this.userRepository.save(user);
+      return user;
     } catch (error) {
-      throw new Error(error.detail ?? ErrorsMessages.MISSING_PARAMS);
+      throw new DatabaseError(error.message + ' ' + error.detail);
     }
-
-    return newUser;
   }
 
   async signIn(input: AuthInterface.ISignInInput) {

--- a/src/utils/mapper/entityMapper.service.ts
+++ b/src/utils/mapper/entityMapper.service.ts
@@ -1,0 +1,15 @@
+import {
+  ClassConstructor,
+  classToPlain,
+  plainToClass
+} from 'class-transformer';
+
+export class EntityMapper {
+  public static mapTo<T, V>(
+    destinationClass: ClassConstructor<T>,
+    entity: V
+  ): T {
+    const entityJson = classToPlain(entity);
+    return plainToClass(destinationClass, entityJson);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,9 +21,11 @@
       "@constants/*": ["src/constants/*"],
       "@utils/*": ["src/utils/*"],
       "@app": ["src/app"],
-      "@server": ["src/server"],
       "@ormconfig": ["ormconfig"],
-      "@views": ["src/views"]
+      "@views": ["src/views"],
+      "@exception/*": ["src/exception/*"],
+      "@dto/*": ["src/dto/*"],
+      "@server": ["src/server"]
     },
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Pull request type

<!-- Please check the type of change your PR introduces: -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
We didn't count with a default exception handler to centralize the correct error treatment against exceptions.

Issue Link: [Add a global exception handler](https://github.com/rootstrap/node-ts-api-base/issues/587)

## What is the new behavior?
On this PR, we created the handler on the ErrorMiddleware bypassing the controller and delegating the catch of exceptions to the ErrorMiddleware which is now in charge of assembly the response on errors. 

In addition to this, we are now fast failing if a request is not correct and only allowing correct requests to surpace the controller layer.

## Other information

We no longer needs for this kind of error handling on the controller.

``` javascript
  @Post('/signin')
  async signIn(
    @BodyParam('email') email: string,
    @BodyParam('password') password: string
  ) {
    try {
      const token = await this.sessionService.signIn({ email, password });
      return { token };
    } catch (error) {
      switch (error?.message) {
        case Errors.MISSING_PARAMS:
          throw new BadRequestError(Errors.MISSING_PARAMS);
        default:
          throw new UnauthorizedError(Errors.INVALID_CREDENTIALS);
      }
    }
  }
}
```

We now can only execute our code and if there's and exception, it will bubble through the app until it reach to the ErrorMiddleware.

```javascript
  @Post('/signup')
  async signUp(@Body({ validate: true }) user: UserDTO, @Res() response: any) {
    const newUser = await this.sessionService.signUp(
      EntityMapper.mapTo(User, user)
    );
    return response.send(omit(newUser, ['password']));
  }
  
  // Then it goes to the Service layer. The service layer will know which kind of exceptions to throw if something goes wrong.
  
    async signUp(user: User) {
    try {
      this.userService.hashUserPassword(user);
      await this.userRepository.save(user);
      return user;
    } catch (error) {
      throw new DatabaseError(error.message + ' ' + error.detail);
    }
  }
```

## Preview

N/A
