### PR TITLE
Fix: Authentication bug on /users method

### DIFF
--- a/__tests__/controllers/auth/delete-session.spec.ts
+++ b/__tests__/controllers/auth/delete-session.spec.ts
@@ -34,6 +34,21 @@ describe('deleting a session', () => {
     expect(response.status).toBe(200);
   });
 
+  it('returns http code 200 when the token starts with Bearer word', async () => {
+    const authFields = {
+      email,
+      password
+    };
+
+    const tokenWithBearer = 'Bearer ' + token;
+
+    const response = await request(app)
+      .post(`${API}/auth/logout`)
+      .set({ Authorization: tokenWithBearer })
+      .send(authFields);
+    expect(response.status).toBe(200);
+  });
+
   it('returns http code 401 because the token was invalidated', async () => {
     const authFields = {
       email,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,6 @@ services:
       ACCESS_TOKEN_LIFE: "${ACCESS_TOKEN_LIFE}"
       RATE_LIMIT_WINDOW: "${RATE_LIMIT_WINDOW}"
       RATE_LIMIT_MAX_REQUESTS: "${RATE_LIMIT_MAX_REQUESTS}"
-      S3_ID: "${S3_ID}"
-      S3_SECRET: "${S3_SECRET}"
-      S3_BUCKETNAME: "${S3_BUCKETNAME}"
     ports:
       - '${PORT}:${PORT}'
     restart: on-failure

--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -17,7 +17,8 @@ export enum ErrorsMessages {
   PASSWORD_ERROR = 'Property password must be longer than or equal to 6 characters',
   // HTTP STANDARD MESSAGES
   INTERNAL_SERVER_ERROR = 'Internal Server Error',
-  BAD_REQUEST_ERROR = 'Bad request error'
+  BAD_REQUEST_ERROR = 'Bad request error',
+  USER_ALREADY_EXISTS = 'A user with this email is already registered'
 }
 
 export const Errors = {

--- a/src/exception/database.error.ts
+++ b/src/exception/database.error.ts
@@ -1,6 +1,6 @@
 import { ErrorsMessages } from '@constants/errorMessages';
 import { BaseError } from './base.error';
-import { HttpStatusCode } from '../constants/httpStatusCode';
+import { HttpStatusCode } from '@constants/httpStatusCode';
 export class DatabaseError extends BaseError {
   constructor(description: string) {
     super(

--- a/src/exception/database.error.ts
+++ b/src/exception/database.error.ts
@@ -1,9 +1,8 @@
 import { ErrorsMessages } from '@constants/errorMessages';
 import { BaseError } from './base.error';
 import { HttpStatusCode } from '../constants/httpStatusCode';
-
 export class DatabaseError extends BaseError {
-  constructor(description) {
+  constructor(description: string) {
     super(
       ErrorsMessages.INTERNAL_SERVER_ERROR,
       HttpStatusCode.INTERNAL_SERVER,

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -25,6 +25,10 @@ export class AuthorizationService {
       if (!token) {
         return false;
       }
+      if (token.startsWith('Bearer ')) {
+        // Remove Bearer from authentication scheme header
+        token = token.replace('Bearer ', '');
+      }
       const payload = await jwt.verifyJWT(token);
       const {
         data: { email }
@@ -36,12 +40,9 @@ export class AuthorizationService {
       if (!!tokenIsBlacklisted) {
         return false;
       }
-      if (token.startsWith('Bearer ')) {
-        // Remove Bearer from authentication scheme header
-        token = token.replace('Bearer ', '');
-      }
       return true;
     } catch (error) {
+      // Here we should do something with the error like loggin
       return false;
     }
   }

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -20,11 +20,11 @@ export class SessionService {
   private readonly userRepository = getRepository<User>(User);
 
   async signUp(user: User) {
+    this.userService.hashUserPassword(user);
     try {
-      this.userService.hashUserPassword(user);
       return await this.userRepository.save(user);
-    } catch (error: any) {
-      throw new DatabaseError(error.message + ' ' + error.detail);
+    } catch (error) {
+      throw new DatabaseError(ErrorsMessages.USER_ALREADY_EXISTS);
     }
   }
 

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -23,7 +23,7 @@ export class SessionService {
     try {
       this.userService.hashUserPassword(user);
       return await this.userRepository.save(user);
-    } catch (error) {
+    } catch (error: any) {
       throw new DatabaseError(error.message + ' ' + error.detail);
     }
   }


### PR DESCRIPTION
## Pull request type

<!-- Please check the type of change your PR introduces: -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
The GET call to /users was retrieving 
```javascript
{
 "name": "AuthorizationRequiredError",
  "httpCode": 401,
  "stack": "Error: \n    at new HttpError (/app/node_modules/src/http-error/HttpError.ts:16:18)\n    at new UnauthorizedError (/app/node_modules/src/http-error/UnauthorizedError.ts:10:5)\n    at new AuthorizationRequiredError (/app/node_modules/src/error/AuthorizationRequiredError.ts:11:5)\n    at handleError (/app/node_modules/src/driver/express/ExpressDriver.ts:122:21)\n    at /app/node_modules/src/driver/express/ExpressDriver.ts:132:31\n    at processTicksAndRejections (internal/process/task_queues.js:93:5)",
  "description": "Authorization is required for request on GET /api/v1/users"
}
```
Because of a bug introduced on the [following PR](https://github.com/rootstrap/node-ts-api-base/pull/550) 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Link: N/A

## What is the new behavior?
The token reaching the verifying method without the `Bearer` word on the token. 
-

## Other information
The tests were running since weren't covering the case of a token within a `Bearer` keyword on it.
<!-- Please add any relevant information that assists the code review. -->

N/A

## Preview

N/A
